### PR TITLE
should be modules.exports not exports.AeroGear

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ install from npm
 
 Require the `unifiedpush-node-sender` library
 
-    var agSender = require( "unifiedpush-node-sender" ).AeroGear,
+    var agSender = require( "unifiedpush-node-sender" ),
         url = "http://localhost:8080/ag-push";
 
 ### Send a Message

--- a/example.js
+++ b/example.js
@@ -1,4 +1,4 @@
-var agSender = require( "./lib/unifiedpush-node-sender" ).AeroGear,
+var agSender = require( "./lib/unifiedpush-node-sender" ),
     url = "http://localhost:8080/ag-push",
     message,
     settings;

--- a/lib/unifiedpush-node-sender.js
+++ b/lib/unifiedpush-node-sender.js
@@ -124,9 +124,6 @@ AeroGear.Sender = function( url ) {
 
 util.inherits( AeroGear.Sender, events.EventEmitter );
 
-exports.AeroGear = AeroGear;
-
-
 /**
     The send Method
     @param {Object} message={} - the message to be passed
@@ -191,3 +188,5 @@ AeroGear.Sender.prototype.send = function( message, settings, callback ) {
 
     return this;
 };
+
+module.exports = AeroGear;

--- a/test/client_sender_test.js
+++ b/test/client_sender_test.js
@@ -3,7 +3,7 @@ var chai = require( "chai" ),
     sinon = require( "sinon" ),
     nock = require( "nock" ),
     expect = require( "chai" ).expect,
-    AeroGear = require( "../lib/unifiedpush-node-sender" ).AeroGear,
+    AeroGear = require( "../lib/unifiedpush-node-sender" ),
     url = "http://localhost:8080/ag-push",
     otherUrl = "http://localhost:8080/ag-push/";
 


### PR DESCRIPTION
This somewhat deals with https://issues.jboss.org/browse/AGPUSH-742,  

currently i was exporting the "AeroGear" namespace, so a user would need to `require('sender').AeroGear` when importing the module.

this change makes it so they no longer have to do that and is more correct in terms of node modules and such
