### PR TITLE
Add API Docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,34 +85,33 @@ The Sender Class,  It is an `EventEmitter`
 ### new Sender(settings)
 
 * `settings` Object
-    * `url` String
-    * `applicationId` String
-    * `masterSecret` String
+    * `url` String - The URL of the Unified Push Server.
+    * `applicationId` String - The id of an Application from the Unified Push Server
+    * `masterSecret` String - The master secret for that Application
 
 ### sender.send([message], [options], [callback])
 
 * `message` Object
-    * `alert` String
-    * `actionCategory` String
-    * `sound` String
-    * `badge` String
-    * `simplePush` String
-    * `userData` Object
-    * `contentAvailable` Boolean
+    * `alert` String - message that will be displayed on the alert UI element
+    * `actionCategory` String -  the identifier of the action category for the interactive notification
+    * `sound` String - The name of a sound file
+    * `badge` String - The number to display as the badge of the app icon
+    * `simplePush` String - simplePush version number
+    * `userData` Object - any extra user data to be passed
+    * `contentAvailable` Boolean - Provide this key with a value of 1 to indicate that new content is available. iOS Only
 
 * `options` Object
 
 * `options.config` Object
-    * `ttl` Number
+    * `ttl` Number - the time to live in seconds. This value is supported by APNs and GCM Only
 
 * `options.criteria` Object
-    * `alias` Array
-    * `deviceType` Array
-    * `categories` Array
-    * `variants` Array
+    * `alias` Array - a list of email or name strings
+    * `deviceType` Array - a list of device types as strings
+    * `categories` Array - a list of categories as strings
+    * `variants` Array - a list of variantID's as strings
 
 * `callback` Function
-
 
 
 ### Event: 'success'

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ The Sender Class,  It is an `EventEmitter`
 
 `function (error) { }`
 
+For more information about the Unified Push Server's REST sender API, look [here](https://aerogear.org/docs/specs/aerogear-unifiedpush-rest/sender/index.html)
+
 ## Development
 
 If you would like to help develop AeroGear you can join our [developer's mailing list](https://lists.jboss.org/mailman/listinfo/aerogear-dev), join #aerogear on Freenode, or shout at us on Twitter @aerogears.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,52 @@ Or you can use a callback
         }
     });
 
-## Documentation
+## API Documentation
 
-For more details about the current release, please consult [our documentation](https://aerogear.org/docs/unifiedpush/).
+### Class: Sender
+
+The Sender Class,  It is an `EventEmitter`
+
+### new Sender(settings)
+
+* `settings` Object
+    * `url` String
+    * `applicationId` String
+    * `masterSecret` String
+
+### sender.send([message], [options], [callback])
+
+* `message` Object
+    * `alert` String
+    * `actionCategory` String
+    * `sound` String
+    * `badge` String
+    * `simplePush` String
+    * `userData` Object
+    * `contentAvailable` Boolean
+
+* `options` Object
+
+* `options.config` Object
+    * `ttl` Number
+
+* `options.criteria` Object
+    * `alias` Array
+    * `deviceType` Array
+    * `categories` Array
+    * `variants` Array
+
+* `callback` Function
+
+
+
+### Event: 'success'
+
+`function () { }`
+
+### Event: 'error'
+
+`function (error) { }`
 
 ## Development
 

--- a/lib/unifiedpush-node-sender.js
+++ b/lib/unifiedpush-node-sender.js
@@ -142,10 +142,10 @@ util.inherits( AeroGear.Sender, events.EventEmitter );
 /**
     The send Method
     @param {Object} message={} - the message to be passed
-    @param {String} [message.alert]
-    @param {String} [message.actionCategory]
-    @param {String} [message.sound]
-    @param {String} [message.badge]
+    @param {String} [message.alert] - message that will be displayed on the alert UI element
+    @param {String} [message.actionCategory] - the identifier of the action category for the interactive notification
+    @param {String} [message.sound] - The name of a sound file
+    @param {String} [message.badge] - The number to display as the badge of the app icon
     @param {String} [message.simplePush] - simplePush version number
     @param {Object} [message.userData={}] - any extra user data to be passed
     @param {Boolean} [message.contentAvailable]


### PR DESCRIPTION
This adds the API doc to the readme.  Similar to https://github.com/websockets/ws/blob/master/doc/ws.md,

This is nice since this is what is displayed on npm

Eventually, i think we should update the link on aerogear.org to point to this