### PR TITLE
A request shouldn't send emtpy arrays in a criteria. AGJS-293

### DIFF
--- a/lib/unifiedpush-node-sender.js
+++ b/lib/unifiedpush-node-sender.js
@@ -95,6 +95,15 @@ function camelToDash( str ) {
         .replace( /([a-z\d])([A-Z])/g, "$1-$2" ).toLowerCase();
 }
 
+function removeEmptyArrays (opt) {
+    for (var o in opt) {
+        if (Array.isArray(opt[o]) && opt[o].length < 1) {
+            delete opt[o];
+        }
+    }
+    return opt;
+}
+
 var AeroGear = {};
 
 /**
@@ -186,7 +195,8 @@ AeroGear.Sender.prototype.send = function( message, options, callback ) {
         url = urlParser.parse( this.getUrl() ),
         newMessage = {};
 
-    newMessage.criteria = options.criteria;
+    // Make sure we remove empty arrays for criteria
+    newMessage.criteria = removeEmptyArrays(options.criteria);
     newMessage.config = options.config;
 
     for( option in options ) {

--- a/test/client_sender_test.js
+++ b/test/client_sender_test.js
@@ -759,3 +759,103 @@ describe( "Sender - Options Params", function() {
         });
     });
 });
+
+describe( "Sender - Options Params", function() {
+    var settings = {
+            url: 'http://localhost:8080/ag-push',
+            applicationId: '1234',
+            masterSecret: '1234'
+        },
+        sender = AeroGear.Sender( settings ),
+        options = {},
+        message = {};
+
+    beforeEach( function() {
+        options = {};
+        message = {};
+    });
+
+    describe( "Option params", function() {
+        it( "send should be called with success with a proper options constructed with a criteria and a criteria with empty array values", function( done ) {
+            nock( "http://localhost:8080" )
+            .matchHeader('Accept', 'application/json')
+            .matchHeader('aerogear-sender', 'AeroGear Node.js Sender')
+            .matchHeader('Content-type', 'application/json')
+            .post( "/ag-push/rest/sender/", {
+                criteria: {
+                },
+                message: {
+                    alert: "Hi"
+                }
+            })
+            .reply( 200,{} );
+
+            message = {
+                alert: "Hi"
+            };
+
+            options = {
+                criteria: {
+                    variants: [],
+                    categories: []
+                }
+            };
+
+            sender.send( message, options ).on( "success", function( response ) {
+                expect( response ).to.be.ok;
+                done();
+            });
+        });
+    });
+});
+
+describe( "Sender - Options Params", function() {
+    var settings = {
+            url: 'http://localhost:8080/ag-push',
+            applicationId: '1234',
+            masterSecret: '1234'
+        },
+        sender = AeroGear.Sender( settings ),
+        options = {},
+        message = {};
+
+    beforeEach( function() {
+        options = {};
+        message = {};
+    });
+
+    describe( "Option params", function() {
+        it( "send should be called with success with a proper options constructed with a criteria and a criteria with empty array values and real values", function( done ) {
+            nock( "http://localhost:8080" )
+            .matchHeader('Accept', 'application/json')
+            .matchHeader('aerogear-sender', 'AeroGear Node.js Sender')
+            .matchHeader('Content-type', 'application/json')
+            .post( "/ag-push/rest/sender/", {
+                criteria: {
+                    alias: ['1', '2']
+                },
+                message: {
+                    alert: "Hi"
+                }
+            })
+            .reply( 200,{} );
+
+            message = {
+                alert: "Hi"
+            };
+
+            options = {
+                criteria: {
+                    variants: [],
+                    categories: [],
+                    alias: ['1', '2']
+                }
+            };
+
+            sender.send( message, options ).on( "success", function( response ) {
+                expect( response ).to.be.ok;
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
This fixes the bug where the sender was sending empty arrays for criteria, which would then not trigger the correct push noitification.


This is to be merged to master.  The 0.7.0 tag will be a separate fix since the formating has changed a little it think