### PR TITLE
adhere to using Error instances vs strings/numbers

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -115,11 +115,15 @@ function send(client) {
 
             request(req, (err, response, body) => {
                 if (err) {
-                    return reject(`Problem with Request: ${err.message}`);
+                    return reject(
+                        new Error(`Problem with UPS Request: ${err.message}`)
+                    );
                 }
 
                 if (response.statusCode !== 200) {
-                    return reject(response.statusCode);
+                    return reject(
+                        new Error(`UPS request returned status code: ${response.statusCode}`)
+                    );
                 }
 
                 return resolve(body);

--- a/lib/unifiedpush-node-sender.js
+++ b/lib/unifiedpush-node-sender.js
@@ -35,8 +35,9 @@ const sender = require('./sender');
 function unifiedPushSenderClient(settings) {
     settings = settings || {};
 
+
     if(!settings.url || !settings.applicationId || !settings.masterSecret) {
-        return Promise.reject('UnifiedPushSenderError');
+        return Promise.reject('settings must contain valid url, applicationId, and masterSecret');
     }
 
     const client = {

--- a/lib/unifiedpush-node-sender.js
+++ b/lib/unifiedpush-node-sender.js
@@ -37,7 +37,9 @@ function unifiedPushSenderClient(settings) {
 
 
     if(!settings.url || !settings.applicationId || !settings.masterSecret) {
-        return Promise.reject('settings must contain valid url, applicationId, and masterSecret');
+        return Promise.reject(
+            new Error('settings must contain valid url, applicationId, and masterSecret')
+        );
     }
 
     const client = {

--- a/test/ups-sender-client-test.js
+++ b/test/ups-sender-client-test.js
@@ -73,7 +73,7 @@ test('test senderClient should reject when url setting', (t) => {
     };
 
     agSender(settings).catch((err) => {
-        t.equal(err, 'UnifiedPushSenderError', 'should return a promise rejection when missing the url');
+        t.equal(err, 'settings must contain valid url, applicationId, and masterSecret', 'should return a promise rejection when missing the url');
         t.end();
     });
 });

--- a/test/ups-sender-client-test.js
+++ b/test/ups-sender-client-test.js
@@ -37,7 +37,7 @@ test('test senderClient url with trailing slash', (t) => {
 
 test('test senderClient should reject when no settings', (t) => {
     agSender().catch((err) => {
-        t.equal(err, 'settings must contain valid url, applicationId, and masterSecret', 'should return a promise rejection when missing the applicationId');
+        t.assert(err.toString().includes('settings must contain valid url, applicationId, and masterSecret'), 'should return a promise rejection when missing the applicationId');
         t.end();
     });
 });
@@ -49,7 +49,7 @@ test('test senderClient should reject when applicationId setting', (t) => {
     };
 
     agSender(settings).catch((err) => {
-        t.equal(err, 'settings must contain valid url, applicationId, and masterSecret', 'should return a promise rejection when missing the applicationId');
+        t.assert(err.toString().includes('settings must contain valid url, applicationId, and masterSecret'), 'should return a promise rejection when missing the applicationId');
         t.end();
     });
 });
@@ -61,7 +61,7 @@ test('test senderClient should reject when masterSecret setting', (t) => {
     };
 
     agSender(settings).catch((err) => {
-        t.equal(err, 'settings must contain valid url, applicationId, and masterSecret', 'should return a promise rejection when missing the masterSecert');
+        t.assert(err.toString().includes('settings must contain valid url, applicationId, and masterSecret'), 'should return a promise rejection when missing the masterSecert');
         t.end();
     });
 });
@@ -73,7 +73,7 @@ test('test senderClient should reject when url setting', (t) => {
     };
 
     agSender(settings).catch((err) => {
-        t.equal(err, 'settings must contain valid url, applicationId, and masterSecret', 'should return a promise rejection when missing the url');
+        t.assert(err.toString().includes('settings must contain valid url, applicationId, and masterSecret'), 'should return a promise rejection when missing the url');
         t.end();
     });
 });

--- a/test/ups-sender-client-test.js
+++ b/test/ups-sender-client-test.js
@@ -37,7 +37,7 @@ test('test senderClient url with trailing slash', (t) => {
 
 test('test senderClient should reject when no settings', (t) => {
     agSender().catch((err) => {
-        t.equal(err, 'UnifiedPushSenderError', 'should return a promise rejection when missing the applicationId');
+        t.equal(err, 'settings must contain valid url, applicationId, and masterSecret', 'should return a promise rejection when missing the applicationId');
         t.end();
     });
 });
@@ -49,7 +49,7 @@ test('test senderClient should reject when applicationId setting', (t) => {
     };
 
     agSender(settings).catch((err) => {
-        t.equal(err, 'UnifiedPushSenderError', 'should return a promise rejection when missing the applicationId');
+        t.equal(err, 'settings must contain valid url, applicationId, and masterSecret', 'should return a promise rejection when missing the applicationId');
         t.end();
     });
 });
@@ -61,7 +61,7 @@ test('test senderClient should reject when masterSecret setting', (t) => {
     };
 
     agSender(settings).catch((err) => {
-        t.equal(err, 'UnifiedPushSenderError', 'should return a promise rejection when missing the masterSecert');
+        t.equal(err, 'settings must contain valid url, applicationId, and masterSecret', 'should return a promise rejection when missing the masterSecert');
         t.end();
     });
 });

--- a/test/ups-sender-test.js
+++ b/test/ups-sender-test.js
@@ -47,7 +47,7 @@ test('test send success - no options', (t) => {
     });
 });
 
-test('test send failure', (t) => {
+test('test send failure with non 200 response', (t) => {
     nock('http://localhost:8080')
         .matchHeader('Accept', 'application/json')
         .matchHeader('aerogear-sender', 'AeroGear Node.js Sender')
@@ -56,7 +56,27 @@ test('test send failure', (t) => {
         .reply(400);
 
     sender().then((client) => {
-        client.sender.send({}, {}).catch(() => {
+        client.sender.send({}, {}).catch((err) => {
+            t.assert(err instanceof Error);
+            t.assert(err.toString().includes('UPS request returned status code: 400'));
+            t.pass('should be in the catch');
+            t.end();
+        });
+    });
+});
+
+test('test send failure such as connection refused', (t) => {
+    nock('http://localhost:8080')
+        .matchHeader('Accept', 'application/json')
+        .matchHeader('aerogear-sender', 'AeroGear Node.js Sender')
+        .matchHeader('Content-type', 'application/json')
+        .post('/ag-push/rest/sender/')
+        .replyWithError(new Error('ECONNREFUSED'));
+
+    sender().then((client) => {
+        client.sender.send({}, {}).catch((err) => {
+            t.assert(err instanceof Error);
+            t.assert(err.toString().includes('Problem with UPS Request: ECONNREFUSED'));
             t.pass('should be in the catch');
             t.end();
         });


### PR DESCRIPTION
Need to add unit tests still, but these fixes ensure the module follows best practices for error handling by returning an Error Object. We had a bug in production due to the fact that sometimes the _response.statusCode_ is returned - we should perhaps have tested for that, but now UPS gets a patch 😄 