### PR TITLE
ci: add release automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,18 @@ jobs:
       - run:
           name: send coverage report to coveralls
           command: cat ./coverage/lcov.info | ./node_modules/.bin/coveralls
+  npm_publish:
+    working_directory: ~/aerogear
+    docker:
+      # Node 8 LTS
+      - image: circleci/node:lts
+    steps:
+      - checkout
+        # Allows us to authenticate with the npm registry
+      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      - run: CI=true npm run release:prep
+      - run: TAG=$CIRCLE_TAG npm run release:validate
+      - run: TAG=$CIRCLE_TAG npm run publish
 
 workflows:
   version: 2
@@ -93,3 +105,14 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - npm_publish:
+          requires:
+            - test-node-4
+            - test-node-6
+            - test-node-8
+            - test-node-10
+          filters:
+            tags:
+              only: /.*/ # allow anything because tag syntax is validated as part of validate-release.sh
+            branches:
+              ignore: /.*/

--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
     "coverage": "./node_modules/.bin/istanbul cover tape -- test/*-test.js",
     "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
     "ci": "npm run lint && npm run coveralls",
-    "docs": "./node_modules/.bin/jsdoc --verbose -d docs -t ./node_modules/ink-docstrap/template -R README.md index.js ./lib/sender.js ./lib/unifiedpush-node-sender.js"
+    "docs": "./node_modules/.bin/jsdoc --verbose -d docs -t ./node_modules/ink-docstrap/template -R README.md index.js ./lib/sender.js ./lib/unifiedpush-node-sender.js",
+    "release:prep": "./scripts/prepareRelease.sh",
+    "release:validate": "./scripts/validateRelease.sh",
+    "publish": "./scripts/publishRelease.sh"
   },
   "dependencies": {
     "request": "^2.88.0"

--- a/scripts/prepareRelease.sh
+++ b/scripts/prepareRelease.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+echo "Preparing release"
+
+npm install
+npm run test
+npm run lint
+
+echo "Repository is ready for release."

--- a/scripts/publishRelease.sh
+++ b/scripts/publishRelease.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# explicit declaration that this script needs a $TAG variable passed in e.g TAG=1.2.3 ./script.sh
+TAG=$TAG
+
+RELEASE_SYNTAX='^[0-9]+\.[0-9]+\.[0-9]+$'
+PRERELEASE_SYNTAX='^[0-9]+\.[0-9]+\.[0-9]+(-.+)+$'
+
+if [ ! "$CI" = true ]; then
+  echo "Warning: this script should not be run outside of the CI"
+  echo "If you really need to run this script, you can use"
+  echo "CI=true ./scripts/publishRelease.sh"
+  exit 1
+fi
+
+if [[ "$(echo $TAG | grep -E $RELEASE_SYNTAX)" == "$TAG" ]]; then
+  echo "publishing a new release: $TAG"
+  # npm publish
+elif [[ "$(echo $TAG | grep -E $PRERELEASE_SYNTAX)" == "$TAG" ]]; then
+  echo "publishing a new pre release: $TAG"
+  # npm publish --tag next
+else
+  echo "Error: the tag $TAG is not valid. exiting..."
+  exit 1
+fi
+ 

--- a/scripts/validateRelease.sh
+++ b/scripts/validateRelease.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# explicit declaration that this script needs a $TAG variable passed in e.g TAG=1.2.3 ./script.sh
+TAG=$TAG
+TAG_SYNTAX='^[0-9]+\.[0-9]+\.[0-9]+(-.+)*$'
+
+# get version found in package.json
+PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]')
+
+# validate tag has format x.y.z
+if [[ "$(echo $TAG | grep -E $TAG_SYNTAX)" == "" ]]; then
+  echo "tag $TAG is invalid. Must be in the format x.y.z or x.y.z-SOME_TEXT"
+  exit 1
+fi
+
+# validate that TAG == version found in package.json
+if [[ $TAG != $PACKAGE_VERSION ]]; then
+  echo "tag $TAG is not the same as package version found in package.json $PACKAGE_VERSION"
+  exit 1
+fi
+
+echo "TAG and PACKAGE_VERSION are valid"


### PR DESCRIPTION
This PR adds some basic release automation scripts that will allow us to create automated releases (and prereleases) to npm using a similar approach as our other JavaScript Libraries.

My intention is to release `0.16.1` which will contain the security vulnerability patches we merged in #33 